### PR TITLE
fix: Segmentation and out-of-range errors.

### DIFF
--- a/c2dataviewer/control/scope_controller_base.py
+++ b/c2dataviewer/control/scope_controller_base.py
@@ -11,7 +11,7 @@ from ..model import ConnectionState
 import math
 from .config import Scope
 from PyQt5 import QtWidgets
-import logging
+from pyqtgraph import functions as fn
 
 class ScopeControllerBase:
     def __init__(self, widget, model, parameters, warning, channels=[]):
@@ -55,6 +55,17 @@ class ScopeControllerBase:
         # Setup save configuration button
         self._win.saveConfigButton.clicked.connect(self._on_save_config_action)
 
+
+    def blockParamChangeSignal(self):
+        """
+        Context manager that temporarily disconnects sigTreeStateChanged from
+        parameter_change, preventing recursive calls and SegFaults. Use whenever
+        code inside the controller modifies a parameter value.
+
+            with self.blockParamChangeSignal():
+                child.setValue(...)
+        """
+        return fn.SignalBlock(self.parameters.sigTreeStateChanged, self.parameter_change)
 
     def set_display_mode(self, val):
         self._win.graphicsWidget.set_display_mode(val)
@@ -314,40 +325,32 @@ class ScopeControllerBase:
         self.lastArrays = arraysReceived
         self.arrays = np.append(self.arrays, n)[-10:]
 
-        # Try to disconnect signal to prevent recursive calls of callback and then SegFaults.
-        try:
-            self.parameters.sigTreeStateChanged.disconnect(self.parameter_change)
-            reconnect = True
-        except TypeError:
-            logging.getLogger().error('Impossible to disconnect parameter signal.')
-            reconnect = False
-        for q in self.parameters.child("Statistics").children():
-            if q.name() == 'CPU':
-                q.setValue(cpu)
-            elif q.name() == 'Lost Arrays':
-                q.setValue(self._win.graphicsWidget.lostArrays)
-            elif q.name() == 'Tot. Arrays':
-                q.setValue(self._win.graphicsWidget.arraysReceived)
-            elif q.name() == 'Arrays/Sec':
-                q.setValue(self.arrays.mean())
-            elif q.name() == 'Bytes/Sec':
-                q.setValue(self.arrays.mean() * self._win.graphicsWidget.data_size)
-            elif q.name() == 'Rate':
-                q.setValue(self._win.graphicsWidget.fps)
+        with self.blockParamChangeSignal():
+            for q in self.parameters.child("Statistics").children():
+                if q.name() == 'CPU':
+                    q.setValue(cpu)
+                elif q.name() == 'Lost Arrays':
+                    q.setValue(self._win.graphicsWidget.lostArrays)
+                elif q.name() == 'Tot. Arrays':
+                    q.setValue(self._win.graphicsWidget.arraysReceived)
+                elif q.name() == 'Arrays/Sec':
+                    q.setValue(self.arrays.mean())
+                elif q.name() == 'Bytes/Sec':
+                    q.setValue(self.arrays.mean() * self._win.graphicsWidget.data_size)
+                elif q.name() == 'Rate':
+                    q.setValue(self._win.graphicsWidget.fps)
 
-        try:
-            for q in self.parameters.child("Trigger").children():
-                if q.name() == "Trig Status":
-                    stat_str = 'Disconnected'
-                    if self.trigger_is_monitor:
-                        stat_str = self._win.graphicsWidget.trigger.status()
-                    q.setValue(stat_str)
-                elif q.name() == "Trig Value":
-                    q.setValue(str(self._win.graphicsWidget.trigger.trigger_value))
-        except:
-            pass
-        if reconnect:
-            self.parameters.sigTreeStateChanged.connect(self.parameter_change)
+            try:
+                for q in self.parameters.child("Trigger").children():
+                    if q.name() == "Trig Status":
+                        stat_str = 'Disconnected'
+                        if self.trigger_is_monitor:
+                            stat_str = self._win.graphicsWidget.trigger.status()
+                        q.setValue(stat_str)
+                    elif q.name() == "Trig Value":
+                        q.setValue(str(self._win.graphicsWidget.trigger.trigger_value))
+            except:
+                pass
 
         #handle any auto-adjustments
         if self.trigger_auto_scale and self._win.graphicsWidget.trigger_mode():

--- a/c2dataviewer/control/scopeconfig.py
+++ b/c2dataviewer/control/scopeconfig.py
@@ -18,10 +18,9 @@ PVA object viewer utilities
 @author: Guobao Shen <gshen@anl.gov>
 """
 
-DEFAULT_MINIMUM_CHANNELS_NUMBER : int = 4
-DEFAULT_MINIMUM_WAVEFORMS_NUMBER : int = 4
-DEFAULT_MAXIMUM_CHANNELS_NUMBER : int = 10
-DEFAULT_MAXIMUM_WAVEFORM_NUMBER : int = 10
+MINIMUM_CHANNEL_NUMBER : int = 1
+DEFAULT_CHANNEL_NUMBER : int = 4
+MAXIMUM_CHANNEL_NUMBER : int = 10
 
 class Configure(ScopeConfigureBase):
     """
@@ -80,7 +79,7 @@ class Configure(ScopeConfigureBase):
         :return:
         """
         # get channel counts to display, 4 by default
-        self.counts = self.params.get(Scope.CHANNEL_COUNT, default = DEFAULT_MINIMUM_CHANNELS_NUMBER)
+        self.counts = self.params.get(Scope.CHANNEL_COUNT, default = DEFAULT_CHANNEL_NUMBER)
         channel = []
 
         #Read channel information.  Channel order is
@@ -88,7 +87,7 @@ class Configure(ScopeConfigureBase):
         chan_cfgs = self.params.get_channel_config()
 
         self.counts = max(self.counts, len(chan_cfgs))
-        self.counts = min(self.counts, DEFAULT_MAXIMUM_CHANNELS_NUMBER)
+        self.counts = min(self.counts, MAXIMUM_CHANNEL_NUMBER)
         
         for i in range(self.counts):
             default_cfg = {
@@ -140,7 +139,6 @@ class Configure(ScopeConfigureBase):
             {"name": "PV", "type": "str", "value": pv},
             {"name": "PV status", "type": "str", "value": "Disconnected", "readonly": True},
             {"name": "Start", "type": "bool", "value": start},
-            {'name' : 'Channels', 'type' : 'int', 'value' : self.counts, 'limits' : [1, 10]},
         ]
 
         children.extend(newchildren)
@@ -176,13 +174,13 @@ class Configure(ScopeConfigureBase):
                "type": "group",
                "expanded": True,
                "children": [
-                   {"name": "ArrayId", "type": "list", "limits": id_value, "value": self.default_arrayid},
-                   {"name": "X Axes", "type": "list", "limits": axes, "value": self.default_xaxes},
-                   {"name": "Major Ticks", "type": "int", "value": self.default_major_tick, 'decimals':20},
-                   {"name": "Minor Ticks", "type": "int", "value": self.default_minor_tick, 'decimals':20},
-                   {"name": "Extra Display Fields", "type": "checklist", "value": extra_fields, "limits": extra_fields, "expanded": False},
-                   {"name": "MO Disp Location", "type": "list", "limits": ['top-right', 'bottom-right', 'bottom-left'], "value": mo_display_loc}
-
+                    {"name": "ArrayId", "type": "list", "limits": id_value, "value": self.default_arrayid},
+                    {"name": "X Axes", "type": "list", "limits": axes, "value": self.default_xaxes},
+                    {"name": "Major Ticks", "type": "int", "value": self.default_major_tick, 'decimals':20},
+                    {"name": "Minor Ticks", "type": "int", "value": self.default_minor_tick, 'decimals':20},
+                    {"name": "Extra Display Fields", "type": "checklist", "value": extra_fields, "limits": extra_fields, "expanded": False},
+                    {"name": "MO Disp Location", "type": "list", "limits": ['top-right', 'bottom-right', 'bottom-left'], "value": mo_display_loc},
+                    {'name' : 'Channel count', 'type' : 'int', 'value' : self.counts, 'limits' : [1, 10]},
                    ]
                }
         return cfg

--- a/c2dataviewer/control/scopecontroller.py
+++ b/c2dataviewer/control/scopecontroller.py
@@ -25,6 +25,11 @@ import math
 import statistics
 from typing import Callable
 
+
+MINIMUM_CHANNEL_NUMBER : int = 1
+DEFAULT_CHANNEL_NUMBER : int = 4
+MAXIMUM_CHANNEL_NUMBER : int = 10
+
 class ScopeController(ScopeControllerBase):
 
     def __init__(self, widget, model, parameters, **kwargs):
@@ -37,7 +42,7 @@ class ScopeController(ScopeControllerBase):
         """
         self.color_pattern = ['#FFFF00', '#FF00FF', '#55FF55', '#00FFFF', '#5555FF', '#5500FF', '#FF5555', '#0000FF', '#FFAA00', '#000000']
 
-        nchannels = parameters.child('Acquisition', 'Channels').value()
+        nchannels = parameters.child('Config', 'Channel count').value()
         self.channels = []
         for i in range(nchannels):
             self.channels.append(ScopePlotChannel('None', self.color_pattern[i]))
@@ -107,7 +112,7 @@ class ScopeController(ScopeControllerBase):
             fields = kwargs['fields'].split(',')
             total_fields = len(fields)
             if total_fields > len(self.channels) :
-                self.parameters.child('Acquisition', 'Channels').setValue(total_fields)
+                self.parameters.child('Config', 'Channel count').setValue(total_fields)
                 self.set_channels_number(number = total_fields)
             for i, f in enumerate(fields):
                 chan_name = "Channel %s" % (i + 1)
@@ -158,14 +163,6 @@ class ScopeController(ScopeControllerBase):
             else:
                 yield sep.join(kprefixs + [k]), v
 
-    def execute_later(instruction : Callable[[], None]) -> None :
-        '''
-        Executes instruction after event pile is emptied, avoiding SegFaults. See QtCore's documentation.
-
-        :param instruction: The function to be executed.
-        '''
-        QtCore.QTimer.singleShot(0, instruction)
-
     def muted(self, instruction : Callable[[], None]) -> None :
         '''
         Disconnects then reconnects signal emited on parameter change, avoiding recursive calls and SegFaults.
@@ -187,7 +184,7 @@ class ScopeController(ScopeControllerBase):
         
         :param number: The new number of sections that should be displayed.
         '''
-        if number > 10 or number < 1 or type(number) is not int:
+        if number > MAXIMUM_CHANNEL_NUMBER or number < MINIMUM_CHANNEL_NUMBER or type(number) is not int:
             raise ValueError(f'Invalid channel number: {number}. Must be integer between 1 and 10.')
         previous_number = len(self.channels)
         if previous_number > number:
@@ -195,11 +192,11 @@ class ScopeController(ScopeControllerBase):
             while previous_number > number:
                 self.muted(lambda : self.parameters.child('Channel %s' % previous_number).remove())
                 previous_number -= 1
-        else:
-            while previous_number < number:
-                self.muted(lambda : self.parameters.insertChild(self.parameters.child('Statistics'), Configure.new_channel(previous_number + 1, self.color_pattern[previous_number], ['None'], 0)))
-                self.channels.append(ScopePlotChannel('None', self.color_pattern[previous_number]))
-                previous_number = len(self.channels)
+        else: # If user asked for increase channel count:
+            while previous_number < number: # While there are not enough:
+                self.muted(lambda : self.parameters.insertChild(self.parameters.child('Statistics'), Configure.new_channel(previous_number + 1, self.color_pattern[previous_number], ['None'], 0))) # Add one parameter corresponding to the new channel.
+                self.channels.append(ScopePlotChannel('None', self.color_pattern[previous_number])) # Add one new PlotChannel object to the list.
+                previous_number = len(self.channels) # Update the channel number for while loop.
         self._win.parameterPane.setParameters(self.parameters, showTop = False)
         self.update_fdr()
         self._win.graphicsWidget.setup_plot(channels = self.channels)
@@ -404,13 +401,13 @@ class ScopeController(ScopeControllerBase):
                         self.start_plotting()
                     else:
                         self.stop_plotting()
+                elif childName == 'Config.Channel count':
+                    self.set_channels_number(number = data)
                 elif 'Channel ' in childName:
                     chan, field = childName.split('.')
                     self.set_channel_data(chan, field, data)
                 elif childName == "Config.ArrayId":
                     self.set_arrayid(data)
-                elif childName == 'Acquisition.Channels':
-                    self.set_channels_number(number = data)
                 elif childName == "Config.X Axes":
                     self.set_xaxes(data)
                 elif childName == "Config.Major Ticks":
@@ -623,6 +620,8 @@ class ScopeController(ScopeControllerBase):
         mo_location = self.parameters.child("Config", "MO Disp Location").value()
         if mo_location:
             serializer.set(Scope.MOUSE_OVER_DISPLAY_LOCATION, mo_location)
+
+        serializer.set(Scope.CHANNEL_COUNT, self.parameters.child('Config', 'Channel count').value())
 
         # Serialize channel configurations
         chan_cfgs = []

--- a/c2dataviewer/control/scopecontroller.py
+++ b/c2dataviewer/control/scopecontroller.py
@@ -23,7 +23,6 @@ from ..view.scope_display import PlotChannel as ScopePlotChannel
 from pyqtgraph.Qt import QtCore
 import math
 import statistics
-from typing import Callable
 
 
 MINIMUM_CHANNEL_NUMBER : int = 1
@@ -163,21 +162,6 @@ class ScopeController(ScopeControllerBase):
             else:
                 yield sep.join(kprefixs + [k]), v
 
-    def muted(self, instruction : Callable[[], None]) -> None :
-        '''
-        Disconnects then reconnects signal emited on parameter change, avoiding recursive calls and SegFaults.
-        Should be used each time code modifies a parameter.
-        
-        :param: instruction: The function to be executed.
-        '''
-        # Try to disconnect signal. If already disconnected, TypeError is raised, then execute instruction as it is.
-        try:
-            self.parameters.sigTreeStateChanged.disconnect(self.parameter_change)
-            instruction()
-            self.parameters.sigTreeStateChanged.connect(self.parameter_change)
-        except TypeError:
-            instruction()
-
     def set_channels_number(self, number : int) -> None :
         '''
         Changes the number of channel input sections.
@@ -187,16 +171,18 @@ class ScopeController(ScopeControllerBase):
         if number > MAXIMUM_CHANNEL_NUMBER or number < MINIMUM_CHANNEL_NUMBER or type(number) is not int:
             raise ValueError(f'Invalid channel number: {number}. Must be integer between 1 and 10.')
         previous_number = len(self.channels)
-        if previous_number > number:
-            self.channels = self.channels[: number]
-            while previous_number > number:
-                self.muted(lambda : self.parameters.child('Channel %s' % previous_number).remove())
-                previous_number -= 1
-        else: # If user asked for increase channel count:
-            while previous_number < number: # While there are not enough:
-                self.muted(lambda : self.parameters.insertChild(self.parameters.child('Statistics'), Configure.new_channel(previous_number + 1, self.color_pattern[previous_number], ['None'], 0))) # Add one parameter corresponding to the new channel.
-                self.channels.append(ScopePlotChannel('None', self.color_pattern[previous_number])) # Add one new PlotChannel object to the list.
-                previous_number = len(self.channels) # Update the channel number for while loop.
+        with self.blockParamChangeSignal():
+            if previous_number > number:
+                self.channels = self.channels[: number]
+                while previous_number > number:
+                    self.parameters.child('Channel %s' % previous_number).remove()
+                    previous_number -= 1
+                else: # If user asked for increase channel count:
+                    while previous_number < number: # While there are not enough:
+                        
+                        self.parameters.insertChild(self.parameters.child('Statistics'), Configure.new_channel(previous_number + 1, self.color_pattern[previous_number], ['None'], 0)) # Add one parameter corresponding to the new channel.
+                        self.channels.append(ScopePlotChannel('None', self.color_pattern[previous_number])) # Add one new PlotChannel object to the list.
+                        previous_number = len(self.channels) # Update the channel number for while loop.
         self._win.parameterPane.setParameters(self.parameters, showTop = False)
         self.update_fdr()
         self._win.graphicsWidget.setup_plot(channels = self.channels)
@@ -258,23 +244,27 @@ class ScopeController(ScopeControllerBase):
 
         # fill up the selectable pull down menu for array ID
         child = self.parameters.child("Config").child("ArrayId")
-        self.muted(lambda : child.setLimits(fdr_scalar))
+        with self.blockParamChangeSignal():
+            child.setLimits(fdr_scalar)
         if child.value() != 'None':
             self.set_arrayid(child.value())
-        
+
         # fill up the selectable pull down menu for x axes
         child = self.parameters.child("Config").child("X Axes")
-        self.muted(lambda : child.setLimits(fdr))
+        with self.blockParamChangeSignal():
+            child.setLimits(fdr)
         if child.value() != 'None':
             self.set_xaxes(child.value())
                 
         child = self.parameters.child("Trigger").child("Data Time Field")
         # Preserve current value before updating limits
         current_value = child.value()
-        self.muted(lambda : child.setLimits(fdr))
+        with self.blockParamChangeSignal():
+            child.setLimits(fdr)
         # Restore value if it's still valid
         if current_value != 'None' and current_value in fdr:
-            self.muted(lambda : child.setValue(current_value))
+            with self.blockParamChangeSignal():
+                child.setValue(current_value)
         if child.value() != 'None':
             self._win.graphicsWidget.trigger.data_time_field = child.value()
         
@@ -282,19 +272,22 @@ class ScopeController(ScopeControllerBase):
             chan_name = "Channel %s" % (idx + 1)
             child = self.parameters.child(chan_name)
             c = child.child("Field")
-            self.muted(lambda : c.setLimits(fdr))
+            with self.blockParamChangeSignal():
+                c.setLimits(fdr)
             if c.value() != 'None':
                 self.set_channel_data(chan_name, 'Field', c.value())
 
         child = self.parameters.child('Config').child('Extra Display Fields')
         # Preserve current values before updating limits
         current_values = child.value()
-        self.muted(lambda : child.setLimits(fdr_all))
+        with self.blockParamChangeSignal():
+            child.setLimits(fdr_all)
         # Restore values that are still valid
         if current_values:
             valid_values = [v for v in current_values if v in fdr_all]
             if valid_values:
-                self.muted(lambda : child.setValue(valid_values))
+                with self.blockParamChangeSignal():
+                    child.setValue(valid_values)
             
     def __failed_connection_callback(self, flag):
         """
@@ -317,7 +310,8 @@ class ScopeController(ScopeControllerBase):
                 self.start_plotting()                
             
     def connection_changed(self, state, msg):
-        self.muted(lambda : self.parameters.child("Acquisition", 'PV status').setValue(state))
+        with self.blockParamChangeSignal():
+            self.parameters.child("Acquisition", 'PV status').setValue(state)
 
         if state == 'Failed to connect':
             self.connection_timer_signal.sig.emit(False)
@@ -462,7 +456,8 @@ class ScopeController(ScopeControllerBase):
         if self.buffer_unit == 'Objects':
             if self.object_size:
                 nobj = math.ceil(size / self.object_size)
-                self.muted(lambda : self.parameters.child("Acquisition").child("Buffer (Objects)").setValue(nobj))
+                with self.blockParamChangeSignal():
+                    self.parameters.child("Acquisition").child("Buffer (Objects)").setValue(nobj)
                 self.__calc_buffer_size()
             else:
                 self._win.graphicsWidget.update_buffer(size)
@@ -480,7 +475,8 @@ class ScopeController(ScopeControllerBase):
 
         param = self.parameters.child("Acquisition").child("Buffer (%s)" % (self.buffer_unit))
         newname = "Buffer (%s)" % (name)
-        self.muted(lambda : param.setName(newname))
+        with self.blockParamChangeSignal():
+            param.setName(newname)
         self.buffer_unit = name
 
         #Update buffer size based on current number of samples
@@ -491,7 +487,8 @@ class ScopeController(ScopeControllerBase):
                 nobj = self.parameters.child("Acquisition").child("Buffer (Objects)").value()
                 if nobj == 0:
                     #default to 1 object
-                    self.muted(lambda : self.parameters.child("Acquisition").child("Buffer (Objects)").setValue(1))
+                    with self.blockParamChangeSignal():
+                        self.parameters.child("Acquisition").child("Buffer (Objects)").setValue(1)
                 self.__calc_buffer_size()
 
     def set_object_size(self, size):
@@ -547,7 +544,8 @@ class ScopeController(ScopeControllerBase):
         
         try:                
             super().start_plotting()
-            self.muted(lambda : self.parameters.child("Acquisition").child("Start").setValue(1))
+            with self.blockParamChangeSignal():
+                self.parameters.child("Acquisition").child("Start").setValue(1)
         except Exception as e:
             self.parameters.child("Acquisition").child("Start").setValue(0)
             self.notify_warning('Failed to start plotting: ' + str(e))
@@ -558,7 +556,8 @@ class ScopeController(ScopeControllerBase):
         :return:
         """
         super().stop_plotting()
-        self.muted(lambda : self.parameters.child("Acquisition").child("Start").setValue(0))
+        with self.blockParamChangeSignal():
+            self.parameters.child("Acquisition").child("Start").setValue(0)
         # Stop data source
         self.model.stop()
 

--- a/c2dataviewer/control/scopecontroller.py
+++ b/c2dataviewer/control/scopecontroller.py
@@ -389,13 +389,21 @@ class ScopeController(ScopeControllerBase):
 
                 if childName == "Acquisition.PV":
                     # stop DAQ and update pv info
-                    self.stop_plotting()
-                    self.model.update_device(data, restart=False)
-                    if data != "":
-                        self.update_fdr()
-                    else:
-                        self.update_fdr(empty=True)
-                    self.reset_object()
+                    try:
+                        self.stop_plotting()
+                        self.model.update_device(data, restart=False)
+                        if data != "":
+                            self.update_fdr()
+                        else:
+                            self.update_fdr(empty=True)
+
+                        # Recalculate object size and readjust buffer size
+                        # if PV name changed
+                        self.auto_buffer_size = True
+                        self.object_size_tally = []
+                        self.object_size = None
+                    except Exception as e:
+                        self.notify_warning('Failed to update PV: ' + (str(e)))
                 elif childName == "Acquisition.Start":
                     if data:
                         self.start_plotting()
@@ -498,11 +506,6 @@ class ScopeController(ScopeControllerBase):
         self.object_size = size
         self.__calc_buffer_size()
 
-    def reset_object(self) -> None :
-        self.auto_buffer_size = True
-        self.object_size = None
-        self.object_size_tally = []
-        
     def monitor_callback(self, data):
         # Calculate object size
         objlen = 0

--- a/c2dataviewer/model/pvapy_plugins.py
+++ b/c2dataviewer/model/pvapy_plugins.py
@@ -17,6 +17,8 @@ from threading import Lock
 from collections import deque
 from statistics import mean
 import enum
+import logging
+from typing import Callable
 
 import pvaccess as pva
 from pvaccess import PvaException
@@ -99,7 +101,7 @@ class PollStrategy:
             self.ctx.channel.asyncGet(self._data_callback, self._err_callback, '')
         except pva.PvaException:
             #error because too many asyncGet calls at once.  Ignore
-            pass
+            logging.getLogger().exception('Failed to poll with PollStrategy.')
         
     def start(self):
         """
@@ -166,11 +168,10 @@ class MonitorStrategy:
         Stops the PV monitor
         """
         try:
-            self.ctx.channel.setConnectionCallback(None)
             self.ctx.channel.stopMonitor()
-            self.ctx.channel.unsubscribe('monitorCallback')
+            self.ctx.channel.setConnectionCallback(None)
         except PvaException:
-            pass
+            logging.getLogger().exception('Failed to stop Monitor.')
 
 
 class ConnectionState(enum.Enum):
@@ -311,7 +312,7 @@ class Channel:
             self.channel.asyncGet(data_callback, error_callback, '')
         except pva.PvaException:
             #error because too many asyncGet calls at once.  Ignore
-            pass
+            logging.getLogger().exception('Failed to get async with Channel.')
         
 class DataSource:
     def __init__(self, timer_factory=None, default=None):

--- a/c2dataviewer/model/pvapy_plugins.py
+++ b/c2dataviewer/model/pvapy_plugins.py
@@ -101,7 +101,7 @@ class PollStrategy:
             self.ctx.channel.asyncGet(self._data_callback, self._err_callback, '')
         except pva.PvaException:
             #error because too many asyncGet calls at once.  Ignore
-            logging.getLogger().exception('Failed to poll with PollStrategy.')
+            logging.getLogger().debug('Failed to poll with PollStrategy.')
         
     def start(self):
         """
@@ -171,7 +171,7 @@ class MonitorStrategy:
             self.ctx.channel.stopMonitor()
             self.ctx.channel.setConnectionCallback(None)
         except PvaException:
-            logging.getLogger().exception('Failed to stop Monitor.')
+            logging.getLogger().debug('Failed to stop Monitor.')
 
 
 class ConnectionState(enum.Enum):
@@ -312,7 +312,7 @@ class Channel:
             self.channel.asyncGet(data_callback, error_callback, '')
         except pva.PvaException:
             #error because too many asyncGet calls at once.  Ignore
-            logging.getLogger().exception('Failed to get async with Channel.')
+            logging.getLogger().debug('Failed to get async with Channel.')
         
 class DataSource:
     def __init__(self, timer_factory=None, default=None):


### PR DESCRIPTION
**`ScopeController.__init__`**: The number of channels is now stored in the `Parameter` object via the config and retrieved by `ScopeController` at this point. This avoids errors when the user uses the `.cfg` file to configure fewer than four channels (since `Configure` only creates two `Channels i` parameters; when the controller tries to access the third, for example during `update_fdr`, the parameter is not found).

**`ScopeController.execute_later`**: Implementation of a function that waits for the call stack to be emptied before executing an instruction. This function addresses segmentation issues when different threads attempt to modify parameters, especially when channels connect and request updates of the `'PV Status'` parameter.

**`ScopeController.muted`**: Addition of a function that allows executing an instruction after disconnection and before reconnection of the parameter-change signal (useful for changing a parameter without triggering the callback function).

**`ScopeController.set_channel_number`**: Implementation of a feature that allows changing the number of channels displayed on screen. This implementation addresses the following error: when the user specifies more fields on the command line than the number of channels requested in the `.cfg` file, an error is raised. The function therefore allows the user to modify the number of acquisition channels and is also called in the previously mentioned case to avoid the error.

Use of `ScopeController.muted` to control parameter changes originating from the code.

**`ScopeController.parameter_change`**: Removal of exception handling in the `if childName == "Acquisition.PV"` block since error handling is already implemented inside `ScopeController.update_fdr`.

**`ScopeControllerBase.update_status`**: Disconnection of the parameter-change signal before updating the statistics parameters, and reconnection afterward. On the first call of this function, the signal is normally not yet connected; the `try-except` structure allows handling the exception raised when Python tries to disconnect the signal while it is not yet connected.

**`MonitorStrategy.stop`**: Removal of an unnecessary line that was raising an error.

**`Configure.new_channel`**: The code generating the dictionary is moved into a separate function that can be called by `ScopeController`.

**`Configure.parse`**: Change in the order of function calls: `assemble_channel` must be called before `assemble_acquisition` so that the number of channels written in `'Acquisition'` is the effective numbers.